### PR TITLE
Add support for required tables and showing only tables listed in the configuration.

### DIFF
--- a/src/NraDatabaseExport.App/.gitignore
+++ b/src/NraDatabaseExport.App/.gitignore
@@ -2,5 +2,3 @@ bin/
 obj/
 publish/
 *.user
-
-appsettings.*.json

--- a/src/NraDatabaseExport.App/Options/DbTableOptionListItem.cs
+++ b/src/NraDatabaseExport.App/Options/DbTableOptionListItem.cs
@@ -14,5 +14,10 @@
 		/// Gets or sets the name of the owner of the table.
 		/// </summary>
 		public string? OwnerName { get; set; }
+
+		/// <summary>
+		/// Gets or sets the flag indicating whether the table should exist or not.
+		/// </summary>
+		public bool IsRequired { get; set; }
 	}
 }

--- a/src/NraDatabaseExport.App/Options/ExportOptions.cs
+++ b/src/NraDatabaseExport.App/Options/ExportOptions.cs
@@ -39,6 +39,11 @@ namespace NraDatabaseExport.App.Options
 		public string DatabaseName { get; set; }
 
 		/// <summary>
+		/// Gets or sets the flag indicating whether to show only listed tables or existing tables as well.
+		/// </summary>
+		public bool ListedTablesOnly { get; set; }
+
+		/// <summary>
 		/// Gets or sets the list of tables.
 		/// </summary>
 		public DbTableOptionListItem[] Tables { get; set; }

--- a/src/NraDatabaseExport.App/Slides/SelectDatabaseSlide.xaml
+++ b/src/NraDatabaseExport.App/Slides/SelectDatabaseSlide.xaml
@@ -48,18 +48,35 @@
 				</Style>
 			</ListBox.ItemContainerStyle>
 		</ListBox>
-		<Label Grid.Row="3" Grid.Column="0"
-			x:Uid="DatabaseLabel"
-			HorizontalAlignment="Left"
-			VerticalAlignment="Top"
-			Content="База данни:"
+		<StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+			HorizontalAlignment="Stretch"
+			Orientation="Horizontal"
+			>
+			<Label
+				x:Uid="DatabasesCountLabel"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Content="Общо бази данни:"
 			/>
-		<TextBlock Grid.Row="3" Grid.Column="1"
-			HorizontalAlignment="Left"
-			VerticalAlignment="Center"
-			FontWeight="Heavy"
-			Text="{Binding SelectedDatabase.Name}"
+			<TextBlock
+				HorizontalAlignment="Left"
+				VerticalAlignment="Center"
+				FontWeight="Heavy"
+				Text="{Binding DatabasesCount}"
 			/>
+			<Label
+				x:Uid="SelectedDatabaseLabel"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Content="Избрана база данни:"
+				/>
+			<TextBlock
+				HorizontalAlignment="Left"
+				VerticalAlignment="Center"
+				FontWeight="Heavy"
+				Text="{Binding SelectedDatabase.Name}"
+				/>
+		</StackPanel>
 		<StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
 			Orientation="Horizontal"
 			HorizontalAlignment="Right">

--- a/src/NraDatabaseExport.App/Slides/SelectTablesSlide.xaml
+++ b/src/NraDatabaseExport.App/Slides/SelectTablesSlide.xaml
@@ -70,7 +70,6 @@
 			ItemsSource="{Binding Tables}"
 			AutoGenerateColumns="False"
 			SelectionMode="Extended"
-			
 			>
 			<DataGrid.Columns>
 				<DataGridTemplateColumn
@@ -81,6 +80,7 @@
 							<CheckBox
 								HorizontalAlignment="Center"
 								IsChecked="{Binding Path=IsSelected, UpdateSourceTrigger=PropertyChanged}"
+								IsEnabled="{Binding Path=CanExport}"
 								/>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -93,18 +93,47 @@
 					/>
 			</DataGrid.Columns>
 		</DataGrid>
-		<Label Grid.Row="4" Grid.Column="0"
-			x:Uid="DatabaseLabel"
-			HorizontalAlignment="Left"
-			VerticalAlignment="Top"
-			Content="Брой таблици:"
+		<StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+			HorizontalAlignment="Stretch"
+			Orientation="Horizontal"
+			>
+			<Label
+				x:Uid="TablesCountLabel"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Content="Общо таблици:"
 			/>
-		<TextBlock Grid.Row="4" Grid.Column="1"
-			HorizontalAlignment="Left"
-			VerticalAlignment="Center"
-			FontWeight="Heavy"
-			Text="{Binding SelectedTablesCount}"
+			<TextBlock
+				HorizontalAlignment="Left"
+				VerticalAlignment="Center"
+				FontWeight="Heavy"
+				Text="{Binding TablesCount}"
 			/>
+			<Label
+				x:Uid="SelectedTablesCountLabel"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Content="Избрани таблици:"
+			/>
+			<TextBlock
+				HorizontalAlignment="Left"
+				VerticalAlignment="Center"
+				FontWeight="Heavy"
+				Text="{Binding SelectedTablesCount}"
+			/>
+			<Label
+				x:Uid="MissingTablesCountLabel"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Content="Брой липсващи таблици:"
+			/>
+			<TextBlock
+				HorizontalAlignment="Left"
+				VerticalAlignment="Center"
+				FontWeight="Heavy"
+				Text="{Binding MissingTablesCount}"
+			/>
+		</StackPanel>
 		<StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
 			Orientation="Horizontal"
 			HorizontalAlignment="Right">

--- a/src/NraDatabaseExport.App/ViewModels/DbTableExportStatus.cs
+++ b/src/NraDatabaseExport.App/ViewModels/DbTableExportStatus.cs
@@ -6,12 +6,20 @@
 	public enum DbTableExportStatus
 	{
 		/// <summary>
-		/// Not applicable
+		/// Missing
 		/// </summary>
 		/// <remarks>
-		/// The table has not been selected for import.
+		/// The table is required but missing.
 		/// </remarks>
-		NotApplicable,
+		Missing,
+
+		/// <summary>
+		/// Skipped
+		/// </summary>
+		/// <remarks>
+		/// The table has been skipped because it was not selected for export.
+		/// </remarks>
+		Skipped,
 
 		/// <summary>
 		/// Busy

--- a/src/NraDatabaseExport.App/ViewModels/DbTableViewModel.cs
+++ b/src/NraDatabaseExport.App/ViewModels/DbTableViewModel.cs
@@ -31,6 +31,12 @@ namespace NraDatabaseExport.App.ViewModels
 				: $"{OwnerName}.{Name}";
 
 		/// <summary>
+		/// Gets the flag indicating whether the data from the table can be exported or not.
+		/// </summary>
+		public bool CanExport
+			=> ExportStatus != DbTableExportStatus.Missing;
+
+		/// <summary>
 		/// Gets or sets the flag indicating whether the item is selected or not.
 		/// </summary>
 		public bool IsSelected
@@ -45,7 +51,15 @@ namespace NraDatabaseExport.App.ViewModels
 		public DbTableExportStatus? ExportStatus
 		{
 			get => _exportStatus;
-			set => SetProperty(ref _exportStatus, value);
+			set
+			{
+				if (!SetProperty(ref _exportStatus, value))
+				{
+					return;
+				}
+
+				NotifyPropertyChanged(nameof(CanExport));
+			}
 		}
 
 		/// <summary>

--- a/src/NraDatabaseExport.App/appsettings.archimed.json
+++ b/src/NraDatabaseExport.App/appsettings.archimed.json
@@ -6,82 +6,102 @@
 		"UserName": null,
 		"Password": null,
 		"DatabaseName": null,
+		"ListedTablesOnly": true,
 		"Tables": [
 			{
 				"OwnerName": "archimed",
-				"Name": "E_OBJECTS"
+				"Name": "E_OBJECTS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "archimed",
-				"Name": "EX_ENTITIES"
+				"Name": "EX_ENTITIES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "archimed",
-				"Name": "E_LOG"
+				"Name": "E_LOG",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "archimed",
-				"Name": "E_LOGOBJECTS"
+				"Name": "E_LOGOBJECTS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "CASH_REGISTERS"
+				"Name": "CASH_REGISTERS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "CASHREG_MEMBERS"
+				"Name": "CASHREG_MEMBERS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "eprocess",
-				"Name": "CORRESPS"
+				"Name": "CORRESPS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "finance",
-				"Name": "Sales"
+				"Name": "Sales",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "CASH_REQUESTS"
+				"Name": "CASH_REQUESTS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "CASHREG_DOCUMENTS"
+				"Name": "CASHREG_DOCUMENTS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "CASHREG_FINISHES"
+				"Name": "CASHREG_FINISHES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "INTERESTS"
+				"Name": "INTERESTS",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "SERVICES"
+				"Name": "SERVICES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "SERVICE_PRICES"
+				"Name": "SERVICE_PRICES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "MEASURES"
+				"Name": "MEASURES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "INVOICES"
+				"Name": "INVOICES",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "INVOICES_DET"
+				"Name": "INVOICES_DET",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "RENTS_DOSSIER"
+				"Name": "RENTS_DOSSIER",
+				"IsRequired": true
 			},
 			{
 				"OwnerName": "municipal",
-				"Name": "RENTS_DOSSIER_RENTS"
+				"Name": "RENTS_DOSSIER_RENTS",
+				"IsRequired": true
 			}
 		],
 		"ExportProviderType": "Csv",


### PR DESCRIPTION
- On the "Select Database", show the number of databases in the RDBMS.
- On the "Select Tables" slide, include tables listed in the application settings as required.
- On the "Select Tables" slide, disable tables listed in the application settings as required but missing from the database.
- On the "Select Tables" slide, show the number of tables in the list, as well as the number of missing tables.